### PR TITLE
Make safety comment less incorrect

### DIFF
--- a/code/examples/unsafe_2.rs
+++ b/code/examples/unsafe_2.rs
@@ -1,12 +1,12 @@
 use std::mem::MaybeUninit;
 
 fn main() {
-    // Safety: all bitpatterns are valid for u32
+    // Safety: all bitpatterns are valid for u16
     let random_number: u8 = unsafe { MaybeUninit::uninit().assume_init() };
 
     let very_random_number = if random_number <= 100 {
         unsafe {
-            // Safety: all bitpatterns are valid for u32
+            // Safety: all bitpatterns are valid for u16
             let rng_array: [u32; 100] = MaybeUninit::uninit().assume_init();
             // Safety: The `random_number` is in bounds
             *rng_array.get_unchecked(random_number as usize)


### PR DESCRIPTION
There was some debate at RustNL about this comment saying `u32` when it should be `u8`. Since we couldn't reach a consensus as to whether it should be `u32` or `u8` I propose we change it to `u16` as a compromise and to resolve this blocker in favor of making progress on this key issue.