### PR TITLE
Rename "borrowck" category to "borrow checker"

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -22,10 +22,10 @@
 - [Trait Solver 6](./trait_solver/6.md)
 - [Trait Solver 7](./trait_solver/7.md)
 
-# Borrowck
+# Borrow Checker
 
-- [Borrowck 1](./borrowck/1.md)
-- [Borrowck 2](./borrowck/2.md)
-- [Borrowck 3](./borrowck/3.md)
-- [Borrowck 4](./borrowck/4.md)
-- [Borrowck 5](./borrowck/5.md)
+- [Borrow Checker 1](./borrowck/1.md)
+- [Borrow Checker 2](./borrowck/2.md)
+- [Borrow Checker 3](./borrowck/3.md)
+- [Borrow Checker 4](./borrowck/4.md)
+- [Borrow Checker 5](./borrowck/5.md)

--- a/src/borrowck/1.md
+++ b/src/borrowck/1.md
@@ -1,4 +1,4 @@
-# Borrowck 1 @WaffleLapkin @BoxyUwU
+# Borrow Checker 1 @WaffleLapkin @BoxyUwU
 
 ```rust
 {{#include ../../code/examples/borrowck_1.rs}}

--- a/src/borrowck/2.md
+++ b/src/borrowck/2.md
@@ -1,4 +1,4 @@
-# Borrowck 2 @WaffleLapkin @BoxyUwU
+# Borrow Checker 2 @WaffleLapkin @BoxyUwU
 
 ```rust
 {{#include ../../code/examples/borrowck_2.rs}}

--- a/src/borrowck/3.md
+++ b/src/borrowck/3.md
@@ -1,4 +1,4 @@
-# Borrowck 3 @BoxyUwU
+# Borrow Checker 3 @BoxyUwU
 
 ```rust
 {{#include ../../code/examples/borrowck_3.rs}}

--- a/src/borrowck/4.md
+++ b/src/borrowck/4.md
@@ -1,4 +1,4 @@
-# Borrowck 4 @BoxyUwU @WaffleLapkin
+# Borrow Checker 4 @BoxyUwU @WaffleLapkin
 
 ```rust
 {{#include ../../code/examples/borrowck_4.rs}}

--- a/src/borrowck/5.md
+++ b/src/borrowck/5.md
@@ -1,4 +1,4 @@
-# Borrowck 5 @WaffleLapkin @BoxyUwU
+# Borrow Checker 5 @WaffleLapkin @BoxyUwU
 
 ```rust
 {{#include ../../code/examples/borrowck_5.rs}}


### PR DESCRIPTION
Resolves #16

I'm a bit concerned that this will make the name too big for mobile for example, but mopbile expirience is kinda fucked anyway, so this is probably fine <img src="https://cdn.discordapp.com/emojis/534473694475714561.webp?size=96&quality=lossless" alt="ferristhumbsup" height="18">.