### PR TITLE
Add details to Unsafe 2 solution

### DIFF
--- a/src/unsafe/2.md
+++ b/src/unsafe/2.md
@@ -15,4 +15,5 @@
 {{#include ../../code/examples/stderr/unsafe_2.stderr}}
 ```
 
+Even though all bitpatterns are valid for a `u16` (and all integer types in general), creating an integer value from uninitialized memory is still undefined behavior. Since uninitialized memory does not have a fixed value, it cannot be used to generate an integer, which are for fixed bit patterns. More details can be found in the [`MaybeUnint` documentation](https://doc.rust-lang.org/std/mem/union.MaybeUninit.html).
 </details>


### PR DESCRIPTION
Adds an explanation for why it's UB past reading uninitialized memory (basically a shortened version of part of the MaybeUnint docs) and a link to the MaybeUnint docs.