### PR TITLE
Remove unused b

### DIFF
--- a/src/borrowck/3.md
+++ b/src/borrowck/3.md
@@ -20,8 +20,6 @@ If you inline calls to `b` it *would* work though:
 
 ```rust
 fn foo(a: &mut u32) -> u32 {
-    let mut b = || &mut *a;
-
     *(&mut *a) = 12;
     *(&mut *a) = 73;
     *a


### PR DESCRIPTION
I think that you can just remove `b` and the solution is clearer / compiles.

Also, very nice quiz! I really like it :)