### PR TITLE
Make unsafe 2 comments more incorrect again

### DIFF
--- a/code/examples/unsafe_2.rs
+++ b/code/examples/unsafe_2.rs
@@ -1,12 +1,12 @@
 use std::mem::MaybeUninit;
 
 fn main() {
-    // Safety: all bitpatterns are valid for u8
+    // Safety: all bitpatterns are valid for u16
     let random_number: u8 = unsafe { MaybeUninit::uninit().assume_init() };
 
     let very_random_number = if random_number <= 100 {
         unsafe {
-            // Safety: all bitpatterns are valid for u32
+            // Safety: all bitpatterns are valid for u16
             let rng_array: [u32; 100] = MaybeUninit::uninit().assume_init();
             // Safety: The `random_number` is in bounds
             *rng_array.get_unchecked(random_number as usize)

--- a/src/unsafe/2.md
+++ b/src/unsafe/2.md
@@ -17,6 +17,8 @@
 
 Even though all *initialized* bitpatterns are valid for integer types, creating an integer value from uninitialized memory is still undefined behavior. More details can be found in the [`MaybeUninit` documentation](https://doc.rust-lang.org/std/mem/union.MaybeUninit.html).
 
-Careful readers may also have noticed that there is an index out of bounds error from checking `random_number <= 100` instead of `random_number < 100`. While this is logically incorrect, it does not result in any UB as the previous line when creating `random_number` is UB and thus all future lines are not executed.
+Careful readers may also have noticed that there is an index out of bounds error from checking `random_number <= 100` instead of `random_number < 100`. While this is logically incorrect, it does not result in any UB as the previous line when creating `random_number` is UB and thus all future lines are not executed by miri.
+
+On top of being incorrect, the safety comments also mention the wrong types (`u16` instead of `u8` and `u32`). While comments don't change the semantics of the program, it's a good idea to keep them up-to-date with the code, especially in unsafe code, to prevent confusion for readers.
 
 </details>


### PR DESCRIPTION
Reverts part of #50 which fixed the comments and add an mention of them being wrong to the explanation.

I also added "by miri" to the note about other UB added by @BoxyUwU, since normally the code could execute after reaching UB. Or, well, at least could look like it does, since the behavior is literally undefined.

I wanted to rephrase the note highlighting that it _would_ be UB, but it simply _doesn't matter_, because UB already happened before. But I couldn't comeup with a good way to say that, so eh.