### PR TITLE
fix: remove duplicate word

### DIFF
--- a/src/misc/9.md
+++ b/src/misc/9.md
@@ -56,7 +56,7 @@ In the first example both `Unit` and `Tuple` are valid expressions, evaluating t
 ```
 
 In the second example, perhaps surprisingly, all of `Unit {}`, `Tuple { 0: 1_u32 }` and `Struct {}` are valid.
-Both tuple and unit structs both support `Struct {}` syntax as it is useful for macros.
+Tuple and unit structs both support `Struct {}` syntax as it is useful for macros.
 
 ---
 


### PR DESCRIPTION
Another option would be keeping the *”Both”* at the beginning and removing the later one. But I found the proposed style more readable.