### PR TITLE
fix: `Unit` conceptually desugars to `Unit {}`

### DIFF
--- a/src/misc/9.md
+++ b/src/misc/9.md
@@ -34,7 +34,7 @@ The name of a unit struct either refers to the *type* of the struct or the impli
 struct Unit;
 
 // conceptually desugars to...
-struct Unit;
+struct Unit {};
 const Unit: Unit = /* not important */;
 ```
 


### PR DESCRIPTION
This change fixes the incorrect claim I had introduced in https://github.com/BoxyUwU/rust-quiz/pull/95.

Tuple and unit structs conceptually desugar to *plain* structs.